### PR TITLE
Fix lumper configuration parsing 

### DIFF
--- a/src/vmm/src/config/builder.rs
+++ b/src/vmm/src/config/builder.rs
@@ -5,8 +5,8 @@ use std::path::PathBuf;
 
 impl VMMConfig {
     /// Create the builder to generate a vmm config
-    pub fn builder() -> VMMConfigBuilder {
-        VMMConfigBuilder::default()
+    pub fn builder(num_vcpus: u8, mem_size_mb: u32, kernel_path: &str) -> VMMConfigBuilder {
+        VMMConfigBuilder::new(num_vcpus, mem_size_mb, kernel_path)
     }
 }
 

--- a/src/vmm/src/config/mod.rs
+++ b/src/vmm/src/config/mod.rs
@@ -5,7 +5,7 @@ mod builder;
 
 #[derive(Debug, PartialEq)]
 pub struct NetConfig {
-    tap_name: String,
+    pub tap_name: String,
 }
 
 /// VMM configuration.


### PR DESCRIPTION
In the last PR I've done (#12) I've implemented the builder pattern for the configuration. And as I was working on macOS I had problems running lumper (nested vm...) & I thought it was on my side, so I got it merged. 

It was not, my code wasn't working as expected, this PR fixes it (I tested it this time on the proper computer :)) with the non-regression test for it.