### PR TITLE
lumper: add initramfs support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,10 @@ struct VMMOpts {
     #[clap(short, long)]
     kernel: String,
 
+    /// initramfs path
+    #[clap(short, long)]
+    initramfs: Option<String>,
+
     /// Number of virtual CPUs assigned to the guest
     #[clap(short, long, default_value = "1")]
     cpus: u8,
@@ -51,6 +55,7 @@ impl TryFrom<VMMOpts> for VMMConfig {
             VMMConfig::builder(opts.cpus, opts.memory, opts.kernel).map_err(Error::ConfigParse)?;
 
         Ok(builder
+            .initramfs(opts.initramfs)
             .tap(opts.tap)
             .map_err(Error::ConfigParse)?
             .console(opts.console)
@@ -98,6 +103,7 @@ mod tests {
             memory: 256,
             verbose: 0,
             console: console.clone(),
+            initramfs: None,
             tap: Some(tap.clone()),
         };
         let cfg = VMMConfig::try_from(opts)?;
@@ -129,6 +135,7 @@ mod tests {
             memory: 256,
             verbose: 0,
             console,
+            initramfs: None,
             tap,
         };
         let cfg = VMMConfig::try_from(opts);

--- a/src/vmm/src/config/builder.rs
+++ b/src/vmm/src/config/builder.rs
@@ -1,6 +1,7 @@
 use crate::config;
 use crate::config::{KernelConfig, NetConfig, VMMConfig};
 use std::convert::TryInto;
+use std::path::PathBuf;
 
 impl VMMConfig {
     /// Create the builder to generate a vmm config
@@ -17,6 +18,7 @@ impl VMMConfig {
 #[derive(Debug, Default)]
 pub struct VMMConfigBuilder {
     kernel: KernelConfig,
+    initramfs: Option<PathBuf>,
     cpus: u8,
     memory: u32,
     verbose: i32,
@@ -29,6 +31,7 @@ impl VMMConfigBuilder {
     pub fn build(self) -> VMMConfig {
         VMMConfig {
             kernel: self.kernel,
+            initramfs: self.initramfs,
             cpus: self.cpus,
             memory: self.memory,
             verbose: self.verbose,
@@ -61,6 +64,14 @@ impl VMMConfigBuilder {
 
     pub fn console(mut self, console: Option<String>) -> Self {
         self.console = console;
+        self
+    }
+
+    pub fn initramfs(mut self, initramfs_path: Option<String>) -> Self {
+        self.initramfs = match initramfs_path {
+            Some(initramfs) => Some(PathBuf::from(initramfs)),
+            None => None,
+        };
         self
     }
 

--- a/src/vmm/src/config/mod.rs
+++ b/src/vmm/src/config/mod.rs
@@ -31,6 +31,9 @@ pub struct VMMConfig {
     /// Linux kernel path
     pub kernel: KernelConfig,
 
+    /// Initramfs path
+    pub initramfs: Option<PathBuf>,
+
     /// Number of virtual CPUs assigned to the guest
     pub cpus: u8,
 

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -317,7 +317,7 @@ impl VMM {
     pub fn configure(&mut self, cfg: VMMConfig) -> Result<()> {
         self.configure_console(cfg.console)?;
         self.configure_memory(cfg.memory)?;
-        let kernel_load = kernel::kernel_setup(&self.guest_memory, cfg.kernel, None)?;
+        let kernel_load = kernel::kernel_setup(&self.guest_memory, cfg.kernel, cfg.initramfs)?;
         self.configure_io()?;
         self.configure_vcpus(cfg.cpus, kernel_load)?;
 


### PR DESCRIPTION
#### Ready to be reviewed
PR to support loading initramfs separated from the kernel.
Using `--initramfs` CLI option we can specify a file which will be used as the initial file system.

@sameo 
Signed-off-by: croumegous <cyril.roumegous@gmail.com>