### PR TITLE
lumper: Quick start using Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM debian:bullseye
+RUN apt-get update && apt install -y curl wget git make cpio gcc bc build-essential
+WORKDIR /app
+COPY . .
+
+RUN bash kernel/mkkernel.sh \
+    && bash rootfs/mkrootfs.sh
+
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y 
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN cargo build --release

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Project is experimental and should not be used in any production systems.**
 
-## Quick start
+## Quick start (without Docker)
 
 ### Prerequisites
 
@@ -51,6 +51,17 @@ To see all the available arguments :
 
 ```bash
 ./target/release/lumper --help
+```
+
+## Quick start (with Docker)
+If you have `docker` installed you can use the Dockerfile directly.
+```bash
+docker build -t lumper .
+docker run --device=/dev/kvm -it lumper bash
+```
+Then you can launch a sample VM:
+```bash
+./target/release/lumper --kernel linux-cloud-hypervisor/vmlinux --initramfs initramfs.img
 ```
 
 ## How to contribute ?


### PR DESCRIPTION
I added a Dockerfile and updated readme for easier Quickstart.
It is also useful to avoid user-specific bugs and errors when running lumper.

(example depends on initramfs support)