### PR TITLE
Add no console option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "linux-loader"

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,14 +59,14 @@ fn main() -> Result<(), Error> {
         opts.cpus,
         opts.memory,
         &opts.kernel,
-        opts.console,
+        opts.console.clone(),
         opts.initramfs,
         opts.net,
     )
     .map_err(Error::VmmConfigure)?;
 
     // Run the VMM
-    vmm.run().map_err(Error::VmmRun)?;
+    vmm.run(opts.console.is_none()).map_err(Error::VmmRun)?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ fn main() -> Result<(), Error> {
     .map_err(Error::VmmConfigure)?;
 
     // Run the VMM
-    vmm.run(opts.console.is_none()).map_err(Error::VmmRun)?;
+    vmm.run().map_err(Error::VmmRun)?;
 
     Ok(())
 }

--- a/src/vmm/Cargo.lock
+++ b/src/vmm/Cargo.lock
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.108"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "linux-loader"

--- a/src/vmm/src/cpu/mod.rs
+++ b/src/vmm/src/cpu/mod.rs
@@ -224,7 +224,7 @@ impl Vcpu {
     }
 
     /// vCPU emulation loop.
-    pub fn run(&mut self) {
+    pub fn run(&mut self, no_console: bool, should_stop: Arc<Mutex<bool>>) {
         // Call into KVM to launch (VMLAUNCH) or resume (VMRESUME) the virtual CPU.
         // This is a blocking function, it only returns for either an error or a
         // VM-Exit. In the latter case, we can inspect the exit reason.
@@ -233,11 +233,16 @@ impl Vcpu {
                 // The VM stopped (Shutdown ot HLT).
                 VcpuExit::Shutdown | VcpuExit::Hlt => {
                     println!("Guest shutdown: {:?}. Bye!", exit_reason);
-                    let stdin = io::stdin();
-                    let stdin_lock = stdin.lock();
-                    stdin_lock.set_canon_mode().unwrap();
 
-                    unsafe { libc::exit(0) };
+                    if no_console {
+                        *should_stop.lock().unwrap() = true;
+                    } else {
+                        let stdin = io::stdin();
+                        let stdin_lock = stdin.lock();
+                        stdin_lock.set_canon_mode().unwrap();
+
+                        unsafe { libc::exit(0) };
+                    }
                 }
 
                 // This is a PIO write, i.e. the guest is trying to write

--- a/src/vmm/src/kernel.rs
+++ b/src/vmm/src/kernel.rs
@@ -44,7 +44,7 @@ const HIMEM_START: u64 = 0x0010_0000; // 1 MB
 /// Address where the kernel command line is written.
 const CMDLINE_START: u64 = 0x0002_0000;
 // Default command line
-pub const DEFAULT_CMDLINE: &str = "console=ttyS0 i8042.nokbd reboot=k panic=1 pci=off";
+pub const DEFAULT_CMDLINE: &str = "i8042.nokbd reboot=k panic=1 pci=off";
 
 fn add_e820_entry(
     params: &mut boot_params,

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -12,7 +12,7 @@ use std::any::Any;
 use std::fs::File;
 use std::io::stdout;
 use std::os::unix::io::AsRawFd;
-use std::os::unix::net::{UnixListener, UnixStream};
+use std::os::unix::net::UnixListener;
 use std::os::unix::prelude::RawFd;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -341,7 +341,7 @@ impl VMM {
     }
 
     // Run all virtual CPUs.
-    pub fn run(&mut self, no_console: bool) -> Result<()> {
+    pub fn run(&mut self) -> Result<()> {
         let mut unix_socket_name = String::from("/tmp/vmm.sock");
         while Path::new(&unix_socket_name).exists() {
             let rng = rand::rand_alphanumerics(8);
@@ -430,7 +430,6 @@ impl VMM {
 
                 if connections.iter().any(|c| c.as_raw_fd() == event_data) {
                     use vmm_sys_util::signal::Killable;
-                    println!("Shutting down");
                     handlers.iter().for_each(|handler| {
                         handler.kill(9).unwrap();
                     });


### PR DESCRIPTION
When a running VM stops, the VMM is blocked and never returns. 
This is due to the epoll's loop (in lib.rs) that is used to listen to event and prompt stdin, the epoll::wait() being a blocking function. 



In order to use the lib in another context (lambdo project), we need for the VMM to finish. 
Moreover, we don't want to have output from VM being printed on our console.

To do that, we will allow to stop outputting to ttyS0 (if no console is specified)
And in case the VM stop running, we will stop the VMM