### PR TITLE
feat: add an irq allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +290,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vm-allocator"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "565b6886b7dd1b3bf34ec9243d90a97db4f2a83c2416caa52fcc95fd255d45e4"
+dependencies = [
+ "libc",
+ "thiserror",
+]
 
 [[package]]
 name = "vm-device"
@@ -301,6 +331,7 @@ dependencies = [
  "kvm-ioctls",
  "libc",
  "linux-loader",
+ "vm-allocator",
  "vm-device",
  "vm-memory",
  "vm-superio",

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -18,3 +18,4 @@ vmm-sys-util = "0.11.1"
 vm-device = { git = "https://github.com/rust-vmm/vm-device", rev = "5847f12" }
 
 vm-superio = "0.7.0"
+vm-allocator = "0.1.0"


### PR DESCRIPTION
It will be used to allocate irq for virtio devices. Use `self.irq_allocator.allocate_id()` to allocate an irq.

fixes #46 